### PR TITLE
Retter feil som har skjedd etter oppgradering av jackson

### DIFF
--- a/src/main/kotlin/no/nav/amt_arena_ords_proxy/client/ords/ArenaOrdsClient.kt
+++ b/src/main/kotlin/no/nav/amt_arena_ords_proxy/client/ords/ArenaOrdsClient.kt
@@ -16,6 +16,6 @@ data class PersonIdWithFnr(
 )
 
 data class Arbeidsgiver(
-	val bedriftsnr: Int,
+	val bedriftsnr: Int?,
 	val orgnrMorselskap: Int,
 )

--- a/src/main/kotlin/no/nav/amt_arena_ords_proxy/client/ords/ArenaOrdsClientImpl.kt
+++ b/src/main/kotlin/no/nav/amt_arena_ords_proxy/client/ords/ArenaOrdsClientImpl.kt
@@ -92,7 +92,7 @@ class ArenaOrdsClientImpl(
 		}
 
 	private data class HentVirksomhetsnummerResponse(
-		val bedriftsnr: Int,
+		val bedriftsnr: Int?,
 		val orgnrMorselskap: Int,
 	)
 

--- a/src/main/kotlin/no/nav/amt_arena_ords_proxy/controller/OrdsController.kt
+++ b/src/main/kotlin/no/nav/amt_arena_ords_proxy/controller/OrdsController.kt
@@ -34,6 +34,7 @@ class OrdsController(
 		return FnrDto(fnr)
 	}
 
+	//Brukes av valp
 	@GetMapping("/arbeidsgiver")
 	@ProtectedWithClaims(issuer = Issuer.AZURE_AD)
 	fun hentArbeidsgiver(

--- a/src/main/kotlin/no/nav/amt_arena_ords_proxy/utils/OrgNrUtils.kt
+++ b/src/main/kotlin/no/nav/amt_arena_ords_proxy/utils/OrgNrUtils.kt
@@ -1,7 +1,7 @@
 package no.nav.amt_arena_ords_proxy.utils
 
 object OrgNrUtils {
-	fun orgNrtoStr(orgNr: Int): String {
+	fun orgNrtoStr(orgNr: Int?): String {
 		val strBuilder = StringBuilder(orgNr.toString())
 
 		// Dette går utifra at vi kun håndterer norske orgnr som alltid er 9 tegn


### PR DESCRIPTION
Retter feil som har skjedd som følge av oppgradering av jackson som førte til at defaultverdi for FAIL_ON_NULL_FOR_PRIMITIVES gikk fra false til true. Når arena da returnerte null for bedriftsnummer og feltet ikke var definert som nullable, krasjet det med 500 feil

https://trello.com/c/liS7pGBp/265-kall-til-arena-ords-proxy-feiler-for-gjennomf%C3%B8ringer-som-tidligere-har-g%C3%A5tt-ok